### PR TITLE
1050: obmc-console-ssh@.service: add ECDSA and ED25519 keys (#1)

### DIFF
--- a/conf/obmc-console-ssh@.service.d/use-socket.conf.in
+++ b/conf/obmc-console-ssh@.service.d/use-socket.conf.in
@@ -1,4 +1,8 @@
 [Service]
 ExecStart=
-ExecStart=-/usr/sbin/dropbear -r ${DROPBEAR_RSAKEY_DIR}/dropbear_rsa_host_key -c "/usr/bin/obmc-console-client" -i $DROPBEAR_EXTRA_ARGS
+ExecStart=-/usr/sbin/dropbear -r ${DROPBEAR_RSAKEY_DIR}/dropbear_rsa_host_key \
+                              -r ${DROPBEAR_RSAKEY_DIR}/dropbear_ecdsa_host_key \
+                              -r ${DROPBEAR_RSAKEY_DIR}/dropbear_ed25519_host_key \
+                              -c "/usr/bin/obmc-console-client" \
+                              -i $DROPBEAR_EXTRA_ARGS
 StandardInput=socket

--- a/conf/obmc-console-ssh@.service.in
+++ b/conf/obmc-console-ssh@.service.in
@@ -8,7 +8,13 @@ After=dropbearkey.service
 Environment="DROPBEAR_RSAKEY_DIR=/etc/dropbear"
 EnvironmentFile=/etc/default/dropbear
 EnvironmentFile=-/etc/default/obmc-console-client
-ExecStart=/usr/sbin/dropbear -K 5 -r ${DROPBEAR_RSAKEY_DIR}/dropbear_rsa_host_key -c "/usr/bin/obmc-console-client -c /etc/obmc-console/client.%i.conf" -p %i -F $DROPBEAR_EXTRA_ARGS
+ExecStart=/usr/sbin/dropbear -K 5 \
+                             -r ${DROPBEAR_RSAKEY_DIR}/dropbear_rsa_host_key \
+                             -r ${DROPBEAR_RSAKEY_DIR}/dropbear_ecdsa_host_key \
+                             -r ${DROPBEAR_RSAKEY_DIR}/dropbear_ed25519_host_key \
+                             -c "/usr/bin/obmc-console-client -c /etc/obmc-console/client.%i.conf" \
+                             -p %i \
+                             -F $DROPBEAR_EXTRA_ARGS
 SyslogIdentifier=console-client-%i
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process


### PR DESCRIPTION
#### obmc-console-ssh@.service: add ECDSA and ED25519 keys (#1)
```
With RSA-SHA1 being deprecated, have our dropbear server also support
ECDSA and ED25519 keys.

The key generation and support within our standard ssh port 22 was added
via commit [1].

This commit adds support for our virtual console ports that come in via
ssh.

The service files have a somewhat unfortunately named variable,
DROPBEAR_RSAKEY_DIR, which assumed dropbear was only going to support
RSA keys. As this commit shows, dropbear supports multiple key types and
the directory, /etc/dropbear/, has no limitations on the type of key
that can go in that directory. Initially, we changed this variable name
to DROPBEAR_KEY_DIR but upon further investigation we saw that this
naming convention was utilized heavily in the dropbear recipes. To keep
things consistent with dropbear, we left it as DROPBEAR_RSAKEY_DIR even
though other key types will be stored in that directory.

Tested:
- Confirmed port 2200 and 2201 dropbear services loaded new RSA keys
  (via 'ps' command) on p10bmc machine
- Confirmed when an ssh was done to port 2200, it connected, properly
  and listed the following as supported via "ssh -vv":
    host key algorithms: ssh-ed25519,ecdsa-sha2-nistp384,rsa-sha2-256

[1]: https://gerrit.openbmc.org/c/openbmc/openbmc/+/70265

Change-Id: I76dd742654a67645d12856ae8fd15dfe71876b9d

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>```